### PR TITLE
Remove unneeded application definition

### DIFF
--- a/rxpaper/src/main/AndroidManifest.xml
+++ b/rxpaper/src/main/AndroidManifest.xml
@@ -1,11 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.cesarferreira.rxpaper">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.cesarferreira.rxpaper"/>


### PR DESCRIPTION
The library module's AndroidManifest.xml does not need an application definition and it will cause errors if an application that depends on RxPaper uses a different flag such as `supportsRtl=false`.
